### PR TITLE
fix: Refactor custom registry handling to prevent crash on fabric

### DIFF
--- a/common/src/main/java/net/impleri/playerskills/integration/kubejs/events/SkillsRegistrationEventJS.java
+++ b/common/src/main/java/net/impleri/playerskills/integration/kubejs/events/SkillsRegistrationEventJS.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 public class SkillsRegistrationEventJS extends BaseSkillsRegistryEventJS {
-    private static final ResourceKey<Registry<Skill<?>>> SKILL_TYPE_REGISTRY = ResourceKey.createRegistryKey(Skills.REGISTRY_KEY);
-    private static final DeferredRegister<Skill<?>> SKILLS = DeferredRegister.create(PlayerSkills.MOD_ID, SKILL_TYPE_REGISTRY);
+    private static final ResourceKey<Registry<Skill<?>>> SKILL_REGISTRY = ResourceKey.createRegistryKey(Skills.REGISTRY_KEY);
+    private static final DeferredRegister<Skill<?>> SKILLS = DeferredRegister.create(PlayerSkills.MOD_ID, SKILL_REGISTRY);
 
     public SkillsRegistrationEventJS(Map<String, RegistryObjectBuilderTypes.BuilderType<Skill<?>>> types) {
         super(types);
@@ -46,7 +46,7 @@ public class SkillsRegistrationEventJS extends BaseSkillsRegistryEventJS {
         return true;
     }
 
-    public <T> boolean add(String skillName, String type) throws RegistryItemAlreadyExists {
+    public boolean add(String skillName, String type) throws RegistryItemAlreadyExists {
         return add(skillName, type, null);
     }
 

--- a/common/src/main/java/net/impleri/playerskills/registry/SkillTypes.java
+++ b/common/src/main/java/net/impleri/playerskills/registry/SkillTypes.java
@@ -14,13 +14,14 @@ import java.util.Map;
 public abstract class SkillTypes {
     public static final ResourceLocation REGISTRY_KEY = SkillResourceLocation.of("skill_types_registry");
 
-    private static Registrar<SkillType<?>> registry;
+    private static Registrar<SkillType<?>> REGISTRY = Registries.get(PlayerSkills.MOD_ID)
+            .<SkillType<?>>builder(REGISTRY_KEY)
+            .build();
 
+    // Dummy method to ensure static elements are created
     public static void buildRegistry() {
-        if (registry == null) {
-            registry = Registries.get(PlayerSkills.MOD_ID)
-                    .<SkillType<?>>builder(REGISTRY_KEY)
-                    .build();
+        if (!REGISTRY.key().location().equals(REGISTRY_KEY)) {
+            PlayerSkills.LOGGER.warn("Skills registry is invalid.");
         }
     }
 
@@ -28,11 +29,11 @@ public abstract class SkillTypes {
      * Get all SkillTypes registered
      */
     public static List<SkillType<?>> entries() {
-        return registry.entrySet().stream().<SkillType<?>>map(Map.Entry::getValue).toList();
+        return REGISTRY.entrySet().stream().<SkillType<?>>map(Map.Entry::getValue).toList();
     }
 
     private static <T> @Nullable SkillType<T> maybeFind(ResourceLocation name) {
-        @Nullable SkillType<?> type = registry.get(name);
+        @Nullable SkillType<?> type = REGISTRY.get(name);
 
         if (type != null) {
             @SuppressWarnings("unchecked") SkillType<T> castSkill = ((SkillType<T>) type);

--- a/common/src/main/java/net/impleri/playerskills/server/registry/Skills.java
+++ b/common/src/main/java/net/impleri/playerskills/server/registry/Skills.java
@@ -20,18 +20,19 @@ public abstract class Skills {
     /**
      * Initial Registry
      */
-    private static Registrar<Skill<?>> REGISTRY;
+    private static final Registrar<Skill<?>> REGISTRY = Registries.get(PlayerSkills.MOD_ID)
+            .<Skill<?>>builder(REGISTRY_KEY)
+            .build();
 
     /**
      * GAME Registry
      */
     private static final Map<ResourceLocation, Skill<?>> registry = new HashMap<>();
 
+    // Dummy method to ensure static elements are created
     public static void buildRegistry() {
-        if (REGISTRY == null) {
-            REGISTRY = Registries.get(PlayerSkills.MOD_ID)
-                    .<Skill<?>>builder(REGISTRY_KEY)
-                    .build();
+        if (!REGISTRY.key().location().equals(REGISTRY_KEY)) {
+            PlayerSkills.LOGGER.warn("Skills registry is invalid.");
         }
     }
 


### PR DESCRIPTION
Changes in [1.2.2](https://github.com/impleri/player-skills/compare/1.2.1...1.2.2) to ensure registries were loaded correctly for Forge broke Fabric. Switching to dummy static methods seems to work for both.

Fixes #21 