### PR TITLE
Fix Java errors

### DIFF
--- a/common/src/main/java/net/impleri/playerskills/restrictions/AbstractRestrictionBuilder.java
+++ b/common/src/main/java/net/impleri/playerskills/restrictions/AbstractRestrictionBuilder.java
@@ -19,13 +19,13 @@ public abstract class AbstractRestrictionBuilder<T extends AbstractRestriction<?
 
     @RemapForJS("if")
     public AbstractRestrictionBuilder<T> condition(Predicate<PlayerDataJS> consumer) {
-        this.condition = (Player player) -> consumer.test(new PlayerDataJS(player));
+        this.condition = (Player player) -> player != null && consumer.test(new PlayerDataJS(player));
 
         return this;
     }
 
     public AbstractRestrictionBuilder<T> unless(Predicate<PlayerDataJS> consumer) {
-        this.condition = (Player player) -> !consumer.test(new PlayerDataJS(player));
+        this.condition = (Player player) -> player == null || !consumer.test(new PlayerDataJS(player));
 
         return this;
     }

--- a/common/src/main/java/net/impleri/playerskills/restrictions/Registry.java
+++ b/common/src/main/java/net/impleri/playerskills/restrictions/Registry.java
@@ -4,6 +4,7 @@ import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 public abstract class Registry<T extends AbstractRestriction<?>> {
     private final Map<ResourceLocation, List<T>> registry = new HashMap<>();
@@ -24,8 +25,8 @@ public abstract class Registry<T extends AbstractRestriction<?>> {
 
     public void add(ResourceLocation name, T restriction) {
         List<T> restrictions = find(name);
-        restrictions.add(restriction);
+        var newRestrictions = Stream.concat(restrictions.stream(), Stream.of(restriction)).toList();
 
-        registry.put(name, restrictions);
+        registry.put(name, newRestrictions);
     }
 }


### PR DESCRIPTION
FIXES
- Sometimes, the condition is checked and player is unexpectedly `null`. Current fix is to assume the condition does not apply
- Java was throwing an error when creating multiple restrictions for the same target. This is because the list of restrictions for that target was being returned as immutable and would not allow `.add`.